### PR TITLE
Reemoved null player name warnings spam

### DIFF
--- a/src/main/java/it/ax3lt/Utils/StreamUtils.java
+++ b/src/main/java/it/ax3lt/Utils/StreamUtils.java
@@ -226,7 +226,10 @@ public class StreamUtils {
                         .collect(Collectors.toList());
 
                 if (lowerCaseLinkedChannels.contains(lowerCaseChannel)) {
-                    linkedUsers.add(Objects.requireNonNull(Bukkit.getOfflinePlayer(uuid).getName()).toLowerCase());
+                    String playerName = Bukkit.getOfflinePlayer(uuid).getName();
+                    if (playerName != null) {
+                        linkedUsers.add(playerName.toLowerCase());
+                    }
                 }
             }
 


### PR DESCRIPTION
Removed the logging of warnings when encountering null player names in the `StreamUtils.java` class.  This change prevents console spam while still handling null cases by skipping over invalid entries: This was caused because Bukkit.getOfflinePlayer(uuid).getName() can return null if the player corresponding to the UUID hasn't logged into the server before, or if the server cannot retrieve their name for some reason