### PR TITLE
Add unit tests for stream utilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>boosted-yaml</artifactId>
             <version>1.3.5</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <repositories>
@@ -116,6 +122,14 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/it/ax3lt/Classes/StreamDataTest.java
+++ b/src/test/java/it/ax3lt/Classes/StreamDataTest.java
@@ -1,0 +1,28 @@
+package it.ax3lt.Classes;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamDataTest {
+
+    @Test
+    void gettersReturnConstructorValues() {
+        StreamData data = new StreamData("stream123", "Just Chatting", "Hanging out");
+
+        assertEquals("stream123", data.getStreamId());
+        assertEquals("Just Chatting", data.getGameName());
+        assertEquals("Hanging out", data.getTitle());
+    }
+
+    @Test
+    void toStringContainsAllFields() {
+        StreamData data = new StreamData("stream123", "Just Chatting", "Hanging out");
+
+        String asString = data.toString();
+
+        assertTrue(asString.contains("stream123"));
+        assertTrue(asString.contains("Just Chatting"));
+        assertTrue(asString.contains("Hanging out"));
+    }
+}

--- a/src/test/java/it/ax3lt/Utils/StreamUtilsTest.java
+++ b/src/test/java/it/ax3lt/Utils/StreamUtilsTest.java
@@ -1,0 +1,67 @@
+package it.ax3lt.Utils;
+
+import it.ax3lt.Classes.StreamData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class StreamUtilsTest {
+
+    @BeforeEach
+    void resetStreamQueue() throws Exception {
+        Field queueField = StreamUtils.class.getDeclaredField("streamQueue");
+        queueField.setAccessible(true);
+        queueField.set(null, new HashMap<String, StreamData>());
+    }
+
+    @Test
+    void enqueueStreamAddsNewChannel() throws Exception {
+        invokeEnqueue("channelOne", "stream1", "Game", "Title");
+
+        Map<String, StreamData> queue = StreamUtils.getStreamQueue();
+        assertEquals(1, queue.size());
+        assertTrue(queue.containsKey("channelOne"));
+
+        StreamData data = queue.get("channelOne");
+        assertNotNull(data);
+        assertEquals("stream1", data.getStreamId());
+        assertEquals("Game", data.getGameName());
+        assertEquals("Title", data.getTitle());
+    }
+
+    @Test
+    void enqueueStreamDoesNotOverwriteExistingChannel() throws Exception {
+        invokeEnqueue("channelOne", "stream1", "Game", "Title");
+        StreamData original = StreamUtils.getStreamQueue().get("channelOne");
+
+        invokeEnqueue("channelOne", "stream2", "Another Game", "Another Title");
+
+        StreamData afterSecondCall = StreamUtils.getStreamQueue().get("channelOne");
+        assertSame(original, afterSecondCall);
+        assertEquals("stream1", afterSecondCall.getStreamId());
+    }
+
+    @Test
+    void dequeueStreamRemovesChannel() throws Exception {
+        Map<String, StreamData> queue = StreamUtils.getStreamQueue();
+        queue.put("channelOne", new StreamData("stream1", "Game", "Title"));
+
+        StreamUtils.dequeueStream("channelOne");
+
+        assertFalse(queue.containsKey("channelOne"));
+    }
+
+    private void invokeEnqueue(String channel, String streamId, String streamGameName, String streamTitle)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method enqueue = StreamUtils.class.getDeclaredMethod("enqueueStream", String.class, String.class, String.class, String.class);
+        enqueue.setAccessible(true);
+        enqueue.invoke(null, channel, streamId, streamGameName, streamTitle);
+    }
+}


### PR DESCRIPTION
## Summary
- add JUnit 5 as a test dependency and configure Surefire for running the test suite
- add unit tests covering StreamData's value accessors and toString contract
- add unit tests for StreamUtils queue management using reflection to exercise private helpers

## Testing
- `mvn -q test` *(fails: unable to resolve maven-resources-plugin from Maven Central due to 403 responses in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d4c29de883308590029b5c956dc7